### PR TITLE
Support #21294 - Add support for group labels

### DIFF
--- a/src/main/java/ca/gc/aafc/dinauser/api/dto/DinaGroupDto.java
+++ b/src/main/java/ca/gc/aafc/dinauser/api/dto/DinaGroupDto.java
@@ -1,11 +1,14 @@
 package ca.gc.aafc.dinauser.api.dto;
 
+import java.util.Map;
+
 import io.crnk.core.resource.annotations.JsonApiId;
 import io.crnk.core.resource.annotations.JsonApiResource;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Singular;
 
 @JsonApiResource(type = "group")
 @Data
@@ -20,6 +23,6 @@ public class DinaGroupDto {
   private String name;
   private String path;
   
-  private String labelEn;
-  private String labelFr;
+  /** map from [ISO language code -> value] */
+  @Singular private Map<String, String> labels;
 }

--- a/src/main/java/ca/gc/aafc/dinauser/api/dto/DinaGroupDto.java
+++ b/src/main/java/ca/gc/aafc/dinauser/api/dto/DinaGroupDto.java
@@ -1,0 +1,25 @@
+package ca.gc.aafc.dinauser.api.dto;
+
+import io.crnk.core.resource.annotations.JsonApiId;
+import io.crnk.core.resource.annotations.JsonApiResource;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@JsonApiResource(type = "group")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DinaGroupDto {
+  
+  @JsonApiId
+  private String internalId;
+
+  private String name;
+  private String path;
+  
+  private String labelEn;
+  private String labelFr;
+}

--- a/src/main/java/ca/gc/aafc/dinauser/api/repository/GroupRepository.java
+++ b/src/main/java/ca/gc/aafc/dinauser/api/repository/GroupRepository.java
@@ -1,0 +1,33 @@
+package ca.gc.aafc.dinauser.api.repository;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Repository;
+
+import ca.gc.aafc.dinauser.api.dto.DinaGroupDto;
+import ca.gc.aafc.dinauser.api.service.DinaGroupService;
+import io.crnk.core.queryspec.QuerySpec;
+import io.crnk.core.repository.ResourceRepositoryBase;
+import io.crnk.core.resource.list.ResourceList;
+
+@Repository
+public class GroupRepository extends ResourceRepositoryBase<DinaGroupDto, String> {
+  
+  @Inject
+  private DinaGroupService service;
+  
+  public GroupRepository() {
+    super(DinaGroupDto.class);
+  }
+
+  @Override
+  public ResourceList<DinaGroupDto> findAll(QuerySpec querySpec) {
+    return querySpec.apply(service.getGroups());
+  }
+  
+  @Override
+  public DinaGroupDto findOne(String id, QuerySpec querySpec) {
+    return service.getGroup(id);
+  }
+
+}

--- a/src/main/java/ca/gc/aafc/dinauser/api/service/DinaGroupService.java
+++ b/src/main/java/ca/gc/aafc/dinauser/api/service/DinaGroupService.java
@@ -1,0 +1,112 @@
+package ca.gc.aafc.dinauser.api.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.resource.GroupResource;
+import org.keycloak.admin.client.resource.GroupsResource;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.GroupRepresentation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import ca.gc.aafc.dinauser.api.dto.DinaGroupDto;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@Log4j2
+public class DinaGroupService {
+  
+  private static final String LABEL_EN_ATTR_KEY = "groupLabelEn";
+  private static final String LABEL_FR_ATTR_KEY = "groupLabelFr";
+  
+  @Autowired
+  private KeycloakClientService keycloakClientService;
+  
+  @Autowired
+  private Keycloak keycloakClient;
+  
+  private RealmResource getRealmResource() {
+    return keycloakClient.realm(keycloakClientService.getRealm());
+  }
+  
+  private GroupsResource getGroupsResource() {
+    return getRealmResource().groups();
+  }
+  
+  private String getStringAttr(final Map<String, List<String>> attrs, final String key) {
+    final List<String> list = attrs.get(key);
+    if (list == null || list.isEmpty()) {
+      log.warn("group has no {}", key);
+      return null;
+    }
+    
+    return list.get(0);
+  }
+  
+  private DinaGroupDto convertFromRepresentation(final GroupRepresentation groupRep) {
+    if (groupRep == null) {
+      log.error("cannot convert null group");
+      return null;
+    }
+    
+    final DinaGroupDto group = new DinaGroupDto();
+    
+    group.setInternalId(groupRep.getId());
+    group.setName(groupRep.getName());
+    group.setPath(groupRep.getPath());
+    
+    final Map<String, List<String>> attributes = groupRep.getAttributes();
+    if (attributes == null) {
+      log.warn("group '{}' has no attribute map", groupRep.getName());
+    } else {
+      log.info("Getting English and French labels for group '{}'", groupRep.getName());
+      group.setLabelEn(getStringAttr(attributes, LABEL_EN_ATTR_KEY));
+      group.setLabelFr(getStringAttr(attributes, LABEL_FR_ATTR_KEY));
+    }
+    
+    return group;
+  }
+  
+  public List<DinaGroupDto> getGroups() {
+    return getGroups(null, null);
+  }
+  
+  public List<DinaGroupDto> getGroups(final Integer firstResult, final Integer maxResults) {
+    log.debug("getting raw group list from {} ({} max)", firstResult, maxResults);
+    final List<GroupRepresentation> rawGroups = getGroupsResource().groups(firstResult, maxResults);
+    
+    log.debug("converting groups");
+    final List<DinaGroupDto> cookedGroups = rawGroups
+        .stream()
+        .map(g -> convertFromRepresentation(g))
+        .collect(Collectors.toList());
+    
+    log.debug("done converting groups; returning");
+    return cookedGroups;
+  }
+  
+  public DinaGroupDto getGroup(final String id) {
+    log.debug("getting group {}", id);
+    
+    final GroupResource groupRes = getGroupsResource().group(id);
+    
+    if (groupRes == null) {
+      log.error("No group with id {}", id);
+      return null;
+    }
+    
+    final GroupRepresentation groupRep = groupRes.toRepresentation();
+    
+    if (groupRep == null) {
+      log.error("Group with id {} has no representation", id);
+      return null;
+    }
+    
+    return convertFromRepresentation(groupRep);
+    
+  }
+
+}

--- a/src/main/java/ca/gc/aafc/dinauser/api/service/DinaGroupService.java
+++ b/src/main/java/ca/gc/aafc/dinauser/api/service/DinaGroupService.java
@@ -13,100 +13,107 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import ca.gc.aafc.dinauser.api.dto.DinaGroupDto;
+import ca.gc.aafc.dinauser.api.dto.DinaGroupDto.DinaGroupDtoBuilder;
 import lombok.extern.log4j.Log4j2;
 
 @Service
 @Log4j2
 public class DinaGroupService {
-  
-  private static final String LABEL_EN_ATTR_KEY = "groupLabelEn";
-  private static final String LABEL_FR_ATTR_KEY = "groupLabelFr";
-  
+
+  private static final String LABEL_ATTR_KEY_PREFIX = "groupLabel-";
+
   @Autowired
   private KeycloakClientService keycloakClientService;
-  
+
   @Autowired
   private Keycloak keycloakClient;
-  
+
   private RealmResource getRealmResource() {
     return keycloakClient.realm(keycloakClientService.getRealm());
   }
-  
+
   private GroupsResource getGroupsResource() {
     return getRealmResource().groups();
   }
-  
+
   private String getStringAttr(final Map<String, List<String>> attrs, final String key) {
     final List<String> list = attrs.get(key);
     if (list == null || list.isEmpty()) {
       log.warn("group has no {}", key);
       return null;
     }
-    
+
     return list.get(0);
   }
-  
+
   private DinaGroupDto convertFromRepresentation(final GroupRepresentation groupRep) {
     if (groupRep == null) {
       log.error("cannot convert null group");
       return null;
     }
-    
-    final DinaGroupDto group = new DinaGroupDto();
-    
-    group.setInternalId(groupRep.getId());
-    group.setName(groupRep.getName());
-    group.setPath(groupRep.getPath());
-    
+
+    DinaGroupDtoBuilder builder = DinaGroupDto.builder()
+        .internalId(groupRep.getId())
+        .name(groupRep.getName())
+        .path(groupRep.getPath());
+
     final Map<String, List<String>> attributes = groupRep.getAttributes();
+    
     if (attributes == null) {
       log.warn("group '{}' has no attribute map", groupRep.getName());
     } else {
-      log.info("Getting English and French labels for group '{}'", groupRep.getName());
-      group.setLabelEn(getStringAttr(attributes, LABEL_EN_ATTR_KEY));
-      group.setLabelFr(getStringAttr(attributes, LABEL_FR_ATTR_KEY));
+      log.info("Getting labels for group '{}'", groupRep.getName());
+      for (final String key : attributes.keySet()) {
+        if (key.startsWith(LABEL_ATTR_KEY_PREFIX)) {
+          final String languageCode = key.substring(LABEL_ATTR_KEY_PREFIX.length());
+          final String label = getStringAttr(attributes, key);
+          log.debug("Label for language {}: {}", languageCode, label);
+          
+          builder = builder.label(languageCode, label);
+        }
+      }
     }
-    
-    return group;
+
+    return builder.build();
   }
-  
+
   public List<DinaGroupDto> getGroups() {
     return getGroups(null, null);
   }
-  
+
   public List<DinaGroupDto> getGroups(final Integer firstResult, final Integer maxResults) {
     log.debug("getting raw group list from {} ({} max)", firstResult, maxResults);
     final List<GroupRepresentation> rawGroups = getGroupsResource().groups(firstResult, maxResults);
-    
+
     log.debug("converting groups");
     final List<DinaGroupDto> cookedGroups = rawGroups
         .stream()
         .map(g -> convertFromRepresentation(g))
         .collect(Collectors.toList());
-    
+
     log.debug("done converting groups; returning");
     return cookedGroups;
   }
-  
+
   public DinaGroupDto getGroup(final String id) {
     log.debug("getting group {}", id);
-    
+
     final GroupResource groupRes = getGroupsResource().group(id);
-    
+
     if (groupRes == null) {
       log.error("No group with id {}", id);
       return null;
     }
-    
+
     final GroupRepresentation groupRep = groupRes.toRepresentation();
-    
+
     if (groupRep == null) {
       log.error("Group with id {} has no representation", id);
       return null;
     }
-    
+
     return convertFromRepresentation(groupRep);
-    
+
   }
 
 }


### PR DESCRIPTION
Groups can be queried, either a list or individual group, from user module. Individual groups have En/Fr labels.