### PR TITLE
35775 User can't set own associated agent

### DIFF
--- a/src/main/java/ca/gc/aafc/dinauser/api/security/UserAuthorizationService.java
+++ b/src/main/java/ca/gc/aafc/dinauser/api/security/UserAuthorizationService.java
@@ -6,6 +6,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import ca.gc.aafc.dina.security.DinaAuthenticatedUser;
@@ -110,7 +111,18 @@ public class UserAuthorizationService extends PermissionAuthorizationService {
     return findHighestRole(user).isHigherOrEqualThan(DinaRole.SUPER_USER);
   }
 
+  /**
+   * Checks if the user represented by the {@link DinaUserDto} is the same as the authenticated user
+   * based on the internalIdentifier value. If one of the values is blank this method returns false;
+   * @param first
+   * @param second
+   * @return
+   */
   private static boolean isSameUser(DinaUserDto first, DinaAuthenticatedUser second) {
+    if (StringUtils.isBlank(first.getInternalId()) || StringUtils.isBlank(second.getInternalIdentifier())) {
+      return false;
+    }
+
     return second.getInternalIdentifier().equalsIgnoreCase(first.getInternalId());
   }
 

--- a/src/test/java/ca/gc/aafc/dinauser/api/UserAuthorizationServiceIT.java
+++ b/src/test/java/ca/gc/aafc/dinauser/api/UserAuthorizationServiceIT.java
@@ -1,0 +1,78 @@
+package ca.gc.aafc.dinauser.api;
+
+import ca.gc.aafc.dina.security.DinaRole;
+import ca.gc.aafc.dina.testsupport.PostgresTestContainerInitializer;
+import ca.gc.aafc.dina.testsupport.security.WithMockKeycloakUser;
+import ca.gc.aafc.dinauser.api.dto.DinaUserDto;
+import ca.gc.aafc.dinauser.api.security.UserAuthorizationService;
+import io.crnk.core.exception.ForbiddenException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = DinaUserModuleApiLauncher.class)
+@TestPropertySource(properties = "spring.config.additional-location=classpath:application-test.yml")
+@ContextConfiguration(initializers = PostgresTestContainerInitializer.class)
+class UserAuthorizationServiceIT {
+
+  @Autowired
+  private UserAuthorizationService userAuthorizationService;
+
+  @Test
+  @WithMockKeycloakUser(internalIdentifier="1d472bf2-514c-40af-9a60-77d6510a39fb", groupRole = {"cnc:SUPER_USER"})
+  void updateOwnRole_lowerRole_allowed() {
+    DinaUserDto updateUser = createUserDto("1d472bf2-514c-40af-9a60-77d6510a39fb", DinaRole.USER);
+
+    assertDoesNotThrow(() -> userAuthorizationService.authorizeUpdate(updateUser));
+  }
+
+  @Test
+  @WithMockKeycloakUser(internalIdentifier="1d472bf2-514c-40af-9a60-77d6510a39fb", groupRole = {"cnc:SUPER_USER"})
+  void updateOwnRole_sameRole_allowed() {
+    DinaUserDto updateUser = createUserDto("1d472bf2-514c-40af-9a60-77d6510a39fb", DinaRole.SUPER_USER);
+
+    assertDoesNotThrow(() -> userAuthorizationService.authorizeUpdate(updateUser));
+  }
+
+  @Test
+  @WithMockKeycloakUser(internalIdentifier="1d472bf2-514c-40af-9a60-77d6510a39fb", groupRole = {"cnc:SUPER_USER"})
+  void updateOwnRole_higherRole_forbidden() {
+    DinaUserDto updateUser = createUserDto("1d472bf2-514c-40af-9a60-77d6510a39fb", DinaRole.DINA_ADMIN);
+
+    assertThrows(ForbiddenException.class, () -> userAuthorizationService.authorizeUpdate(updateUser));
+  }
+
+  @Test
+  @WithMockKeycloakUser(internalIdentifier="1d472bf2-514c-40af-9a60-77d6510a39fb", groupRole = {"cnc:SUPER_USER"})
+  void updateAnotherUserRole_sameRole_forbidden() {
+    DinaUserDto updateUser = createUserDto("internal-999", DinaRole.SUPER_USER); 
+
+    assertThrows(ForbiddenException.class, () -> userAuthorizationService.authorizeUpdate(updateUser));
+  }
+
+  @Test
+  @WithMockKeycloakUser(internalIdentifier="1d472bf2-514c-40af-9a60-77d6510a39fb", groupRole = {"cnc:SUPER_USER"})
+  void updateAnotherUserRole_lowerRole_allowed() {
+    DinaUserDto updateUser = createUserDto("internal-999", DinaRole.USER); 
+
+    assertDoesNotThrow(() -> userAuthorizationService.authorizeUpdate(updateUser));
+  }
+
+  private DinaUserDto createUserDto(String internalId, DinaRole role) {
+    Map<String, Set<String>> rolesPerGroup = new HashMap<>();
+    rolesPerGroup.put("cnc", Set.of(role.getKeycloakRoleName()));
+
+    DinaUserDto userDto = new DinaUserDto();
+    userDto.setInternalId(internalId);
+    userDto.setRolesPerGroup(rolesPerGroup);
+    return userDto;
+  }
+}

--- a/src/test/java/ca/gc/aafc/dinauser/api/security/UserAuthorizationServiceIT.java
+++ b/src/test/java/ca/gc/aafc/dinauser/api/security/UserAuthorizationServiceIT.java
@@ -1,10 +1,12 @@
-package ca.gc.aafc.dinauser.api;
+package ca.gc.aafc.dinauser.api.security;
 
 import ca.gc.aafc.dina.security.DinaRole;
 import ca.gc.aafc.dina.testsupport.PostgresTestContainerInitializer;
 import ca.gc.aafc.dina.testsupport.security.WithMockKeycloakUser;
+import ca.gc.aafc.dinauser.api.DinaUserModuleApiLauncher;
+import ca.gc.aafc.dinauser.api.config.UserModuleTestConfiguration;
 import ca.gc.aafc.dinauser.api.dto.DinaUserDto;
-import ca.gc.aafc.dinauser.api.security.UserAuthorizationService;
+
 import io.crnk.core.exception.ForbiddenException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,7 +20,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest(classes = DinaUserModuleApiLauncher.class)
+@SpringBootTest(classes = {UserModuleTestConfiguration.class, DinaUserModuleApiLauncher.class})
 @TestPropertySource(properties = "spring.config.additional-location=classpath:application-test.yml")
 @ContextConfiguration(initializers = PostgresTestContainerInitializer.class)
 class UserAuthorizationServiceIT {


### PR DESCRIPTION
- Added IT tests for each scenario, updating user's own role as well as other user's roles
- Made changes to logic that blocks updates
- If updating self, should only block if user tries to escalate role instead of blocking updates that sets equal role as well